### PR TITLE
Backport commit 4b19dc1

### DIFF
--- a/gcc/fortran/scanner.c
+++ b/gcc/fortran/scanner.c
@@ -2097,6 +2097,10 @@ preprocessor_line (gfc_char_t *c)
           in the linemap.  Alternative could be using GC or updating linemap to
           point to the new name, but there is no API for that currently.  */
       current_file->filename = xstrdup (filename);
+
+      /* We need to tell the linemap API that the filename changed.  Just
+	 changing current_file is insufficient.  */
+      linemap_add (line_table, LC_RENAME, false, current_file->filename, line);
     }
 
   /* Set new line number.  */

--- a/gcc/testsuite/gfortran.dg/linefile.f90
+++ b/gcc/testsuite/gfortran.dg/linefile.f90
@@ -1,0 +1,18 @@
+! { dg-do compile }
+! { dg-options "-Wall" }
+
+! This will verify that the # <line> <file> directive later does not
+! mess up the diagnostic on this line
+SUBROUTINE s(dummy) ! { dg-warning "Unused" }
+  INTEGER, INTENT(in) :: dummy
+END SUBROUTINE
+
+# 12345 "foo-f"
+SUBROUTINE s2(dummy)
+  INTEGER, INTENT(in) :: dummy
+END SUBROUTINE
+! We want to check that the # directive changes the filename in the
+! diagnostic.  Nothing else really matters here.  dg-regexp allows us
+! to see the entire diagnostic.  We just have to make sure to consume
+! the entire message.
+! { dg-regexp "foo-f\[^\n]*" }


### PR DESCRIPTION
This fixes a reported bug and has already been upstreamed.

commit 4b19dc1551f68df21bf8db8ef6eea48ac92daa64
Author: law <law@138bc75d-0d04-0410-961f-82ee72b054a4>
Date:   Mon May 7 18:24:59 2018 +0000

            * scanner.c (preprocessor_line): Call linemap_add after a line
            directive that changes the current filename.

            * gfortran.dg/linefile.f90: New test.

    git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@260010 138bc75d-0d04-0410-961f-82ee72b054a4