### PR TITLE
 "Backport commit 6325663"

### DIFF
--- a/gcc/fortran/options.c
+++ b/gcc/fortran/options.c
@@ -57,9 +57,6 @@ set_dec_flags (int value)
     | GFC_STD_GNU | GFC_STD_LEGACY;
   gfc_option.warn_std &= ~(GFC_STD_LEGACY | GFC_STD_F95_DEL);
 
-  /* Set -fd-lines-as-comments by default.  */
-  if (value && gfc_current_form != FORM_FREE && gfc_option.flag_d_lines == -1)
-    gfc_option.flag_d_lines = 0;
 
   /* Set other DEC compatibility extensions.  */
   flag_dollar_ok |= value;
@@ -337,8 +334,15 @@ gfc_post_options (const char **pfilename)
 	diagnostic_classify_diagnostic (global_dc, OPT_Wline_truncation,
 					DK_ERROR, UNKNOWN_LOCATION);
     }
-  else if (warn_line_truncation == -1)
-    warn_line_truncation = 0;
+  else
+    {
+      /* With -fdec, set -fd-lines-as-comments by default in fixed form.  */
+      if (flag_dec && gfc_option.flag_d_lines == -1)
+	gfc_option.flag_d_lines = 0;
+
+      if (warn_line_truncation == -1)
+	warn_line_truncation = 0;
+    }
 
   /* If -pedantic, warn about the use of GNU extensions.  */
   if (pedantic && (gfc_option.allow_std & GFC_STD_GNU) != 0)

--- a/gcc/testsuite/gfortran.dg/dec_d_lines_1.f
+++ b/gcc/testsuite/gfortran.dg/dec_d_lines_1.f
@@ -1,0 +1,9 @@
+! { dg-do compile }
+! { dg-options "-ffixed-form -fd-lines-as-code -fdec" }
+!
+! Ensure -fd-lines-as-code is not overridden by -fdec.
+!
+      i = 0
+d     end
+      subroutine s
+D     end

--- a/gcc/testsuite/gfortran.dg/dec_d_lines_2.f
+++ b/gcc/testsuite/gfortran.dg/dec_d_lines_2.f
@@ -1,0 +1,8 @@
+! { dg-do compile }
+! { dg-options "-ffixed-form -fdec" }
+!
+! Ensure -fd-lines-as-comments is enabled by default with -fdec.
+!
+d This is a comment.
+D This line, too.
+      end


### PR DESCRIPTION
Backporting  from upstream to fix a reported bug:

Author: foreese <foreese@138bc75d-0d04-0410-961f-82ee72b054a4>
Date:   Thu Aug 10 12:36:44 2017 +0000

    2017-08-10  Fritz Reese <Reese-Fritz@zai.com>

        gcc/fortran/ChangeLog:

            * options.c (set_dec_flags, gfc_post_options): Only set flag_d_lines
            with -fdec when not set by user.

        gcc/testsuite/ChangeLog:

        gfortran.dg/
            * dec_d_lines_1.f, dec_d_lines_2.f: New.

    git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@251024 138bc75d-0d04-0410-961f-82ee72b054a4